### PR TITLE
🔥 CRITICAL HOTFIX: Import fixes to unblock production

### DIFF
--- a/src/clarity/core/exceptions.py
+++ b/src/clarity/core/exceptions.py
@@ -16,7 +16,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 

--- a/src/clarity/ports/config_ports.py
+++ b/src/clarity/ports/config_ports.py
@@ -11,6 +11,12 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from clarity.core.config_aws import MiddlewareConfig
+else:
+    # For runtime, we need the actual import
+    try:
+        from clarity.core.config_aws import MiddlewareConfig
+    except ImportError:
+        MiddlewareConfig = Any
 
 
 class IConfigProvider(ABC):


### PR DESCRIPTION
## 🚨 PRODUCTION BLOCKER FIX

### Critical Issues Fixed
1. **NameError: name 'Request' is not defined** in exceptions.py
2. **NameError: name 'MiddlewareConfig' is not defined** in config_ports.py

### Root Cause
Missing imports that were causing the application to crash on startup.

### Changes
- Added Request import to exceptions.py
- Added proper MiddlewareConfig import handling to config_ports.py

### Testing
```bash
# This should now work without NameError
SKIP_EXTERNAL_SERVICES=true python -m clarity.main
```

## MERGE IMMEDIATELY - PRODUCTION IS DOWN