### PR TITLE
🔥 CRITICAL HOTFIX #2: Middleware imports

### DIFF
--- a/src/clarity/ports/middleware_ports.py
+++ b/src/clarity/ports/middleware_ports.py
@@ -11,8 +11,18 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-
     from fastapi import Request, Response
+else:
+    # For runtime, we need the actual imports
+    try:
+        from collections.abc import Awaitable
+        from fastapi import Request, Response
+    except ImportError:
+        # Fallback if FastAPI is not available
+        Request = Any
+        Response = Any
+        Awaitable = Any
+        from typing import Any
 
 
 class IMiddleware(ABC):


### PR DESCRIPTION
## 🚨 ANOTHER PRODUCTION BLOCKER

### Issue
Same import problem in a different file\!
- **NameError: name 'Request' is not defined** in middleware_ports.py

### Fix
Added runtime imports for Request, Response, and Awaitable types.

### Testing
This should allow the container to start without NameError.

## MERGE IMMEDIATELY - ALL DEPLOYMENTS ARE FAILING